### PR TITLE
Update runner and provisioner versions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 


### PR DESCRIPTION
The workflow was using dtolnay/rust-action which doesn't exist. Changed to dtolnay/rust-toolchain which is the correct action name.