### PR TITLE
Fix Clippy Warnings

### DIFF
--- a/src/compute/fft.rs
+++ b/src/compute/fft.rs
@@ -189,6 +189,7 @@ pub struct FrequencyKernel {
 
 impl FrequencyKernel {
     /// Create frequency-domain kernel from spatial kernel.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_spatial(
         kernel_data: &[f32],
         width: usize,

--- a/src/compute/flow.rs
+++ b/src/compute/flow.rs
@@ -64,6 +64,7 @@ pub fn compute_flow_field(
 /// Compute flow field into pre-allocated buffers.
 /// This is the allocation-free version for use with pre-allocated buffers.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub fn compute_flow_field_into(
     grad_u_x: &[f32],
     grad_u_y: &[f32],

--- a/src/compute/gpu/propagator.rs
+++ b/src/compute/gpu/propagator.rs
@@ -384,8 +384,8 @@ impl GpuPropagator {
                 label: Some("Step Encoder"),
             });
 
-        let workgroups_x = (width + 15) / 16;
-        let workgroups_y = (height + 15) / 16;
+        let workgroups_x = width.div_ceil(16);
+        let workgroups_y = height.div_ceil(16);
 
         // Stage 1: Convolution + Growth for each kernel
         for (kernel_idx, kernel_config) in self.config.kernels.iter().enumerate() {

--- a/src/compute/reintegration.rs
+++ b/src/compute/reintegration.rs
@@ -56,6 +56,7 @@ pub fn advect_mass(
 /// * `dt` - Time step
 /// * `distribution_size` - Half-width of distribution kernel (s parameter)
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub fn advect_mass_into(
     current: &[f32],
     flow_x: &[f32],

--- a/src/schema/seed.rs
+++ b/src/schema/seed.rs
@@ -156,13 +156,13 @@ fn apply_gaussian(
     let width = grid[channel][0].len();
     let sigma_sq = (radius / 2.0).powi(2);
 
-    for y in 0..height {
-        for x in 0..width {
+    for (y, row) in grid[channel].iter_mut().enumerate().take(height) {
+        for (x, cell) in row.iter_mut().enumerate().take(width) {
             let dx = x as f32 - cx;
             let dy = y as f32 - cy;
             let dist_sq = dx * dx + dy * dy;
             let value = amplitude * (-dist_sq / (2.0 * sigma_sq)).exp();
-            grid[channel][y][x] += value;
+            *cell += value;
         }
     }
 }
@@ -192,9 +192,9 @@ fn apply_noise(
         if c >= grid.len() {
             continue;
         }
-        for y in 0..height {
-            for x in 0..width {
-                grid[c][y][x] += amplitude * lcg_next(&mut state);
+        for row in grid[c].iter_mut().take(height) {
+            for cell in row.iter_mut().take(width) {
+                *cell += amplitude * lcg_next(&mut state);
             }
         }
     }
@@ -215,8 +215,8 @@ fn apply_ring(
     let height = grid[channel].len();
     let width = grid[channel][0].len();
 
-    for y in 0..height {
-        for x in 0..width {
+    for (y, row) in grid[channel].iter_mut().enumerate().take(height) {
+        for (x, cell) in row.iter_mut().enumerate().take(width) {
             let dx = x as f32 - cx;
             let dy = y as f32 - cy;
             let dist = (dx * dx + dy * dy).sqrt();
@@ -226,7 +226,7 @@ fn apply_ring(
                 let inner_falloff = ((dist - inner_radius) / edge_width).min(1.0);
                 let outer_falloff = ((outer_radius - dist) / edge_width).min(1.0);
                 let falloff = inner_falloff.min(outer_falloff);
-                grid[channel][y][x] += amplitude * falloff;
+                *cell += amplitude * falloff;
             }
         }
     }


### PR DESCRIPTION
- Allow too_many_arguments for internal compute functions
- Use div_ceil() instead of manual ceiling division
- Use idiomatic iterators instead of range loops in seed.rs