### PR TITLE
fix(ci): prevent duplicate runs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 env:


### PR DESCRIPTION
## Summary
- Limit push trigger to main branch only so PRs only run CI once via the pull_request event

## Test plan
- [x] Verify this PR only shows 4 CI checks (not 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)